### PR TITLE
feat: 백엔드 CD 환경변수 주입 방식 개선 및 브랜치별 프로필 적용

### DIFF
--- a/ci-cd/backend/cd.yml
+++ b/ci-cd/backend/cd.yml
@@ -39,19 +39,18 @@ jobs:
         env:
           RELEASE_BUCKET: ${{ secrets.RELEASE_BUCKET }}
           TIMESTAMP: ${{ steps.timestamp.outputs.timestamp }}
-          DB_HOST: ${{ secrets.DB_HOST }}
-          DB_PORT: ${{ secrets.DB_PORT }}
-          DB_SCHEMA: ${{ secrets.DB_SCHEMA }}
-          DB_USERNAME: ${{ secrets.DB_USERNAME }}
-          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
-          AI_SERVICE_URL: ${{ secrets.AI_SERVICE_URL }}
+          DOT_ENV: ${{ secrets.DOT_ENV_DEV }}
         with:
           host: ${{ secrets.DEV_HOST }}
           username: ${{ secrets.DEV_USER }}
           key: ${{ secrets.DEV_SSH_KEY }}
-          envs: RELEASE_BUCKET,TIMESTAMP,DB_HOST,DB_PORT,DB_SCHEMA,DB_USERNAME,DB_PASSWORD,AI_SERVICE_URL
+          envs: RELEASE_BUCKET,TIMESTAMP,DOT_ENV
           script: |
             cd /home/ubuntu/backend
+
+            # .env 파일 생성
+            echo "$DOT_ENV" > .env
+            chmod 600 .env
 
             # S3 snapshots에서 최신 jar 다운로드
             NEW_JAR="app-$TIMESTAMP.jar"
@@ -79,11 +78,11 @@ jobs:
               rm -f backend.pid
             fi
 
-            # 새 버전 실행
-            AI_SERVICE_URL=$AI_SERVICE_URL DB_HOST=$DB_HOST DB_PORT=$DB_PORT DB_SCHEMA=$DB_SCHEMA DB_USERNAME=$DB_USERNAME DB_PASSWORD=$DB_PASSWORD \
-              nohup java -jar "$NEW_JAR" > backend.log 2>&1 &
+            # .env 환경변수 로드 후 실행 (dev 프로필)
+            set -a; source .env; set +a
+            nohup java -Dspring.profiles.active=dev -jar "$NEW_JAR" > backend.log 2>&1 &
             echo $! > backend.pid
-            echo "새 버전 실행: $NEW_JAR (PID: $(cat backend.pid))"
+            echo "새 버전 실행: $NEW_JAR (PID: $(cat backend.pid), Profile: dev)"
 
       - name: Health Check
         id: health_check
@@ -112,17 +111,10 @@ jobs:
       - name: Rollback on failure
         if: steps.health_check.outcome == 'failure'
         uses: appleboy/ssh-action@master
-        env:
-          DB_PORT: ${{ secrets.DB_PORT }}
-          DB_SCHEMA: ${{ secrets.DB_SCHEMA }}
-          DB_USERNAME: ${{ secrets.DB_USERNAME }}
-          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
-          AI_SERVICE_URL: ${{ secrets.AI_SERVICE_URL }}
         with:
           host: ${{ secrets.DEV_HOST }}
           username: ${{ secrets.DEV_USER }}
           key: ${{ secrets.DEV_SSH_KEY }}
-          envs: DB_PORT,DB_SCHEMA,DB_USERNAME,DB_PASSWORD,AI_SERVICE_URL
           script: |
             cd /home/ubuntu/backend
 
@@ -137,10 +129,10 @@ jobs:
 
             source .deploy_info
             if [ -n "$PREVIOUS_JAR" ] && [ -f "$PREVIOUS_JAR" ]; then
-              AI_SERVICE_URL=$AI_SERVICE_URL DB_PORT=$DB_PORT DB_SCHEMA=$DB_SCHEMA DB_USERNAME=$DB_USERNAME DB_PASSWORD=$DB_PASSWORD \
-                nohup java -jar "$PREVIOUS_JAR" > backend.log 2>&1 &
+              set -a; source .env; set +a
+              nohup java -Dspring.profiles.active=dev -jar "$PREVIOUS_JAR" > backend.log 2>&1 &
               echo $! > backend.pid
-              echo "롤백 완료: $PREVIOUS_JAR (PID: $(cat backend.pid))"
+              echo "롤백 완료: $PREVIOUS_JAR (PID: $(cat backend.pid), Profile: dev)"
             else
               echo "롤백 실패: 이전 버전 없음"
               exit 1
@@ -192,19 +184,18 @@ jobs:
         env:
           RELEASE_BUCKET: ${{ secrets.RELEASE_BUCKET }}
           TIMESTAMP: ${{ steps.timestamp.outputs.timestamp }}
-          DB_HOST: ${{ secrets.PROD_DB_HOST }}
-          DB_PORT: ${{ secrets.PROD_DB_PORT }}
-          DB_SCHEMA: ${{ secrets.PROD_DB_SCHEMA }}
-          DB_USERNAME: ${{ secrets.PROD_DB_USER }}
-          DB_PASSWORD: ${{ secrets.PROD_DB_PASSWORD }}
-          AI_SERVICE_URL: ${{ secrets.AI_SERVICE_URL }}
+          DOT_ENV: ${{ secrets.DOT_ENV }}
         with:
           host: ${{ secrets.PROD_HOST }}
           username: ${{ secrets.PROD_USER }}
           key: ${{ secrets.PROD_SSH_KEY }}
-          envs: RELEASE_BUCKET,TIMESTAMP,DB_HOST,DB_PORT,DB_SCHEMA,DB_USERNAME,DB_PASSWORD,AI_SERVICE_URL
+          envs: RELEASE_BUCKET,TIMESTAMP,DOT_ENV
           script: |
             cd /home/ubuntu/backend
+
+            # .env 파일 생성
+            echo "$DOT_ENV" > .env
+            chmod 600 .env
 
             # S3 releases에서 최신 버전 찾기
             LATEST_VERSION=$(aws s3 ls s3://$RELEASE_BUCKET/releases/backend/ | sort | tail -1 | awk '{print $2}' | tr -d '/')
@@ -236,11 +227,11 @@ jobs:
               rm -f backend.pid
             fi
 
-            # 새 버전 실행
-            AI_SERVICE_URL=$AI_SERVICE_URL DB_HOST=$DB_HOST DB_PORT=$DB_PORT DB_SCHEMA=$DB_SCHEMA DB_USERNAME=$DB_USERNAME DB_PASSWORD=$DB_PASSWORD \
-              nohup java -jar "$NEW_JAR" > backend.log 2>&1 &
+            # .env 환경변수 로드 후 실행 (prod 프로필)
+            set -a; source .env; set +a
+            nohup java -Dspring.profiles.active=prod -jar "$NEW_JAR" > backend.log 2>&1 &
             echo $! > backend.pid
-            echo "새 버전 실행: $NEW_JAR (PID: $(cat backend.pid))"
+            echo "새 버전 실행: $NEW_JAR (PID: $(cat backend.pid), Profile: prod)"
 
       - name: Health Check
         id: health_check
@@ -269,18 +260,10 @@ jobs:
       - name: Rollback on failure
         if: steps.health_check.outcome == 'failure'
         uses: appleboy/ssh-action@master
-        env:
-          DB_HOST: ${{ secrets.PROD_DB_HOST }}
-          DB_PORT: ${{ secrets.PROD_DB_PORT }}
-          DB_SCHEMA: ${{ secrets.PROD_DB_SCHEMA }}
-          DB_USERNAME: ${{ secrets.PROD_DB_USERNAME }}
-          DB_PASSWORD: ${{ secrets.PROD_DB_PASSWORD }}
-          AI_SERVICE_URL: ${{ secrets.AI_SERVICE_URL }}
         with:
           host: ${{ secrets.PROD_HOST }}
           username: ${{ secrets.PROD_USER }}
           key: ${{ secrets.PROD_SSH_KEY }}
-          envs: DB_HOST,DB_PORT,DB_SCHEMA,DB_USERNAME,DB_PASSWORD,AI_SERVICE_URL
           script: |
             cd /home/ubuntu/backend
 
@@ -295,10 +278,10 @@ jobs:
 
             source .deploy_info
             if [ -n "$PREVIOUS_JAR" ] && [ -f "$PREVIOUS_JAR" ]; then
-              AI_SERVICE_URL=$AI_SERVICE_URL DB_HOST=$DB_HOST DB_PORT=$DB_PORT DB_SCHEMA=$DB_SCHEMA DB_USERNAME=$DB_USERNAME DB_PASSWORD=$DB_PASSWORD \
-                nohup java -jar "$PREVIOUS_JAR" > backend.log 2>&1 &
+              set -a; source .env; set +a
+              nohup java -Dspring.profiles.active=prod -jar "$PREVIOUS_JAR" > backend.log 2>&1 &
               echo $! > backend.pid
-              echo "롤백 완료: $PREVIOUS_JAR (PID: $(cat backend.pid))"
+              echo "롤백 완료: $PREVIOUS_JAR (PID: $(cat backend.pid), Profile: prod)"
             else
               echo "롤백 실패: 이전 버전 없음"
               exit 1


### PR DESCRIPTION
## 요약
- 개별 환경변수 직접 전달 방식에서 .env 파일 기반 환경변수 주입 방식으로 변경
- Spring Boot 실행 시 브랜치별 프로필(dev/prod) 명시적 적용
- 롤백 시에도 동일한 환경변수 로드 및 프로필 적용 방식 일관성 유지

## 작업 내용
- 환경변수 주입 방식 개선
Before: DB_HOST, DB_PORT, DB_SCHEMA, DB_USERNAME, DB_PASSWORD, AI_SERVICE_URL 등 개별 시크릿을 SSH 세션에 직접 전달
After: DOT_ENV_DEV/DOT_ENV 시크릿을 통해 .env 파일 생성 후 source 명령으로 로드

- 브랜치별 프로필 적용
dev 환경: -Dspring.profiles.active=dev
prod 환경: -Dspring.profiles.active=prod

- 보안 강화
.env 파일 권한을 600으로 설정하여 소유자만 읽기/쓰기 가능

## 테스트 방법
- [x] dev 브랜치 push 시 dev 환경 배포 정상 동작 확인
- [x] main 브랜치 push 시 prod 환경 배포 정상 동작 확인
- [x] Health Check 실패 시 롤백 동작 확인
- [x] 애플리케이션 로그에서 활성화된 프로필 확인