### PR TITLE
Fix: removing .pem in key_name

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -197,7 +197,7 @@ resource "aws_instance" "bigbang_instance" {
   ami                    = data.aws_ami.ubuntu.id
   instance_type          = "t3.medium"
   subnet_id              = aws_subnet.prod_public_a.id
-  key_name               = "kateboo-11team.pem"
+  key_name               = "kateboo-11team"
   vpc_security_group_ids = [aws_security_group.ssh.id]
   ipv6_address_count     = 1
   iam_instance_profile   = aws_iam_instance_profile.ec2_profile.name


### PR DESCRIPTION
### Summary
- [x] terraform apply 단계 에러 수정

### 작업 내용
- resource > aws_instance > key_name에 작성되어 있던 값에서 .pem 확장자 부분을 제거했습니다.

### 테스트
- 노트북에서 terraform 명령어 실행이 정상적으로 동작하지 않는 상태이고 16:45경에 에러 해결 과정을 같이 확인했으므로 생략합니다. 

related: #7 