### PR TITLE
feat: adding variable to restrict SSH access

### DIFF
--- a/terraform/modules/network/security_group.tf
+++ b/terraform/modules/network/security_group.tf
@@ -10,7 +10,7 @@ resource "aws_security_group" "bigbang" {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = var.allowed_ssh_cidrs
   }
 
   ingress {

--- a/terraform/modules/network/variables.tf
+++ b/terraform/modules/network/variables.tf
@@ -10,4 +10,8 @@ variable "region" {
   default     = "ap-northeast-2"
 }
 
-
+variable "allowed_ssh_cidrs" {
+  description = "List of CIDR blocks allowed for SSH"
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -8,6 +8,8 @@ module "iam" {
 
 module "network" {
   source = "./modules/network"
+
+  allowed_ssh_cidrs = var.allowed_ssh_cidrs
 }
 
 module "compute" {

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -3,3 +3,8 @@
 # cp terraform.tfvars.example terraform.tfvars 후 수정
 
 deployment_buckets = ["your-deployment-bucket"]
+
+# Optional: limit SSH access to specific CIDRs
+# allowed_ssh_cidrs = ["203.0.113.5/32"]  # 예: 단일 IP만 허용
+# or
+# allowed_ssh_cidrs = ["203.0.113.0/24", "198.51.100.0/24"]  # 여러 CIDR 허용

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -3,3 +3,9 @@ variable "deployment_buckets" {
   type        = list(string)
   default     = []
 }
+
+variable "allowed_ssh_cidrs" {
+  description = "List of CIDR blocks allowed to SSH into instances"
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}


### PR DESCRIPTION
### Summary
- [x] ssh 접근 CIDRs 변수 처리

### 작업 내용 및 PR point
- ssh 접근 허용 인바운드 규칙을 비공개로 관리하기 위해 변수로 처리했고 변수는 tfvars에서 관리됩니다. 이에 따라 tfvars.example 역시 수정했습니다.
- network/security_group의 cidr_blocks는 network/variables에서 읽어옵니다. 
- tfvars에서 관리되는 변수들은 variables에서 선언됩니다.
- terraform.tf에서 terraform/variables를 읽어와 값을 할당합니다. 


closes: #14 