### PR TITLE
fix: using another attribute instead of deprecated one

### DIFF
--- a/terraform/modules/iam/main.tf
+++ b/terraform/modules/iam/main.tf
@@ -40,7 +40,7 @@ resource "aws_iam_role_policy" "ssm_read_policy" {
           "ssm:GetParameters",
           "ssm:GetParametersByPath"
         ]
-        Resource = "arn:aws:ssm:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:parameter/bigbang/*"
+        Resource = "arn:aws:ssm:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:parameter/bigbang/*"
       }
     ]
   })


### PR DESCRIPTION
### Summary
- [x] 테라폼 코드 중 data.aws_region.current.name -> data.aws_region.current.region 

### 작업 내용
- iam/main.tf의 data.aws_region.current.name이 deprecated되었다고 해 공식 문서에서 사용 가능하다고 언급되어 있는 data.aws_region.current.region으로 대체했습니다.
- [참고링크](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region?utm_source=chatgpt.com)

## 테스트
- terraform plan을 했을 때 어떠한 warning도 뜨지 않습니다. 

closes: #15 