### PR TITLE
fix: correcting nginx root path for frontend files

### DIFF
--- a/configs/nginx/default.conf
+++ b/configs/nginx/default.conf
@@ -6,7 +6,7 @@ server {
     server_name service_domain;
 
     # =========================
-    # /api → 백엔드 서버
+    # /api -> 백엔드 서버
     # =========================
     location /api/ {
         proxy_pass http://127.0.0.1:8080;  # 백엔드 포트로 변경
@@ -17,9 +17,9 @@ server {
     }
 
     # =========================
-    # / → 정적 파일(React build)
+    # / -> 정적 파일(React build)
     # =========================
-    root /var/www/frontend/build;          # build 폴더 경로로 변경
+    root /home/ubuntu/frontend;          # build 폴더 경로로 변경
     index index.html;
 
     location / {


### PR DESCRIPTION
## Summary 
- [x] nginx root /var/www/frontend/build;  -> root /home/ubuntu/frontend;  

## 작업 내용 및 PR point
- 파일이 배포된 위치와 nginx가 배포할 파일을 찾는 위치가 맞지 않아 nginx를 수정했습니다.

## 테스트
- 테스트는 배포를 통한 확인이 필요합니다.

closes: #18