### PR TITLE
feat: making ssh key name a variable in terraform

### DIFF
--- a/terraform/modules/compute/ec2.tf
+++ b/terraform/modules/compute/ec2.tf
@@ -18,7 +18,7 @@ resource "aws_instance" "bigbang_instance" {
   ami                    = data.aws_ami.ubuntu.id
   instance_type          = "t3.medium"
   subnet_id              = var.subnet_id
-  key_name               = "kateboo-11team"
+  key_name               = var.key_name
   vpc_security_group_ids = [var.security_group_id]
   ipv6_address_count     = 1
   iam_instance_profile   = var.iam_instance_profile_name

--- a/terraform/modules/compute/variables.tf
+++ b/terraform/modules/compute/variables.tf
@@ -17,3 +17,8 @@ variable "iam_instance_profile_name" {
   description = "IAM instance profile name"
   type        = string
 }
+
+variable "key_name" {
+  description = "EC2 key pair name to use for SSH access"
+  type        = string
+}

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -19,6 +19,8 @@ module "compute" {
   subnet_id                 = module.network.public_subnet_a_id
   security_group_id         = module.network.security_group_id
   iam_instance_profile_name = module.iam.iam_instance_profile_name
+
+  key_name = var.ssh_key_name
 }
 
 # EIP 할당 (root level에서 관리하여 순환참조 방지)

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,10 +1,12 @@
 # terraform.tfvars.example
 # terraform.tfvars에서는 실제 배포에 사용할 bucket 이름으로 변경하세요
 # cp terraform.tfvars.example terraform.tfvars 후 수정
-
 deployment_buckets = ["your-deployment-bucket"]
 
 # Optional: limit SSH access to specific CIDRs
 # allowed_ssh_cidrs = ["203.0.113.5/32"]  # 예: 단일 IP만 허용
 # or
 # allowed_ssh_cidrs = ["203.0.113.0/24", "198.51.100.0/24"]  # 여러 CIDR 허용
+
+# set the EC2 key pair name used for instances
+ssh_key_name = "my-key-pair"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -9,3 +9,8 @@ variable "allowed_ssh_cidrs" {
   type        = list(string)
   default     = ["0.0.0.0/0"]
 }
+
+variable "ssh_key_name" {
+  description = "Name of the EC2 key pair to use for SSH"
+  type        = string
+}


### PR DESCRIPTION
## Summary
- [x] ssh key name 변수화

## 작업 내용 및 PR point
- modules/compute/ec2 에서 변수화, 해당 변수에 대한 선언은 compute/variables에서 이뤄집니다.
- 루트 단에서 tfvars을 읽어오기 위해 변수를 선언하는 작업은 terraform/variables에서 이뤄집니다.
- 변수 값은 tfvars (tfvars.example에 예시 작성)에 작성되어야 합니다. 
- 변수 연결은 terraform.tf에서 이뤄집니다.

## 테스트
- terraform plan 결과 경고문이 뜬 바 없으며 tfvars에서 지정한 변수명으로 맞게 주입되어 리소스를 생성하는 것을 확인했습니다.

Resolved: #22 