### PR TITLE
refactor: reverting the root location for frontend files

### DIFF
--- a/configs/nginx/default.conf
+++ b/configs/nginx/default.conf
@@ -19,7 +19,7 @@ server {
     # =========================
     # / -> 정적 파일(React build)
     # =========================
-    root /home/ubuntu/frontend;          # build 폴더 경로로 변경
+    root /var/www/frontend;          # build 폴더 경로로 변경
     index index.html;
 
     location / {


### PR DESCRIPTION
## Summary
- [x] default.conf root /home/ubuntu 에서 /var/www으로 변경

## 작업 내용 및 PR point
- 이전 PR에서 nginx가 /home/ubuntu를 루트로 정적파일을 서빙하도록 수정했습니다. 하지만 Filesystem Hierarchy Standard (FHS)에 따르면 /home/*은 사용자 개인 작업 공간을, /var/www은 웹서버가 제공하는 컨텐츠를 두는 공간으로 관례가 잡혀있다고 합니다.
- 이에 따라 프론트엔드 cd 배포 파일에서 배포할 폴더를 /var/www/frontend로 수정 완료한 상태이고 현재 ec2 역시 이번 pr 수정본과 동일하게 수정하여 배포 상태가 정상임을 확인 완료한 상태입니다.
- 본 PR은 클라우드 레포지토리 백업 파일에도 해당 수정 사항을 반영하는 내용입니다. 

## 테스트
- 현재 서버 default.conf 파일에 수정 사항 반영 완료, cd 파일에서 배포 파일 위치 /var/www으로 변경 완료 후 배포 테스트 정상 작동 확인 완료

resolved: #23