### PR TITLE
fix(cd): main 브랜치 수동 실행 시 dev 배포 방지

### DIFF
--- a/ci-cd/backend/cd.yml
+++ b/ci-cd/backend/cd.yml
@@ -21,7 +21,7 @@ jobs:
   deploy_dev:
     name: Deploy to Dev Server
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/develop' || github.event_name == 'workflow_dispatch'
+    if: github.ref == 'refs/heads/develop' || (github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main')
 
     steps:
       - name: Configure AWS credentials


### PR DESCRIPTION
## 요약
백엔드 cd 배포 트리거를 수정하였습니다.

## 작업내용
- develop 브랜치에서 수동 트리거 발생시 prod환경과 develop 환경에 동시에 배포되는 문제를 수정했습니다.
- main을 제외한 환경에서 배포를 시도할때 develop 환경에 배포되도록 수정하였습니다.

## 테스트 
- [x] be 레포에서 develop브랜치에서 cd 수동 트리거를 발생시켰을때 develop 환경에만 배포가 진행이 되어야 합니다. 