### PR TITLE
chore http 요청 바디 파일 크기 제한을 50MB로 변경

### DIFF
--- a/configs/nginx/default.conf
+++ b/configs/nginx/default.conf
@@ -6,7 +6,7 @@ server {
     server_name service_domain www.service_domain;
 
     # 파일 업로드 크기 제한
-    client_max_body_size 20m;
+    client_max_body_size 50m;
 
     # =========================
     # /api -> 백엔드 서버


### PR DESCRIPTION
# 요약
- default 을 수정하여 파일 크기 제한은 50MB으로 변경하였습니다.

# 테스트
백엔드 레포지토리에서 정상적으로 진행이 되는점을 확인하였습니다.