### PR TITLE
feat: 부하테스트를 위한 stub-ai 도커파일

### DIFF
--- a/k6-scripts/stub-ai/Dockerfile
+++ b/k6-scripts/stub-ai/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:22-alpine
+
+WORKDIR /app
+
+COPY . .
+
+ENV PORT=8000
+EXPOSE 8000
+
+USER node
+
+CMD ["node", "server.js"]


### PR DESCRIPTION
## 요약
AI API 비용을 절감하기 위해서 Stub ai 서버를 실행시키는 도커 파일을 추가하였습니다.

## 사용방법
이미지를 빌드후에 ECR에서 ai 레포지토리에 태그명을 따로 작성하여 이미지를 push하고 ai 서버에서 실행되도록 합니다.
