### PR TITLE
feat: adding instances for data services - redis, rabbitmq, weaviate

### DIFF
--- a/terraform/envs/dev/main.tf
+++ b/terraform/envs/dev/main.tf
@@ -797,18 +797,6 @@ resource "aws_security_group" "rabbitmq" {
     security_groups = [module.network.app_ai_security_group_id]
   }
 
-  # Optional: RabbitMQ Management UI (15672) from SSH allowlist CIDRs (if provided)
-  dynamic "ingress" {
-    for_each = length(var.allowed_ssh_cidrs) > 0 ? [1] : []
-    content {
-      description = "RabbitMQ management UI (allowed SSH CIDRs)"
-      from_port   = 15672
-      to_port     = 15672
-      protocol    = "tcp"
-      cidr_blocks = var.allowed_ssh_cidrs
-    }
-  }
-
   egress {
     from_port   = 0
     to_port     = 0


### PR DESCRIPTION
### 작업 내용
- redis, rabbitmq, weaviate를 올리는 t3.small 인스턴스를 만들고 user_data를 작성했습니다.
- user_data에서는 ecr 각각의 레포지토리에서 이미지를 가져오고 s3 버킷 각각의 디렉토리에서 docker-compose.yml을 불러와 실행합니다. 